### PR TITLE
Custom timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ terraform-Oracle-BareMetal-Provider
 *.orig
 .idea
 terraform-Oracle-BareMetal-Provider.iml
+terraform-provider-baremetal.iml
 .env
 crash.log
 terraform-encrypted-des.sh

--- a/docs/examples/compute/single-instance/provider.tf
+++ b/docs/examples/compute/single-instance/provider.tf
@@ -3,4 +3,5 @@ provider "baremetal" {
   user_ocid = "${var.user_ocid}"
   fingerprint = "${var.fingerprint}"
   private_key_path = "${var.private_key_path}"
+  timeout_minutes = "${var.timeout_minutes}"
 }

--- a/docs/examples/compute/single-instance/variables.tf
+++ b/docs/examples/compute/single-instance/variables.tf
@@ -14,6 +14,10 @@ variable "AD" {
     default = "1"
 }
 
+variable "timeout_minutes" {
+    default = 5
+}
+
 variable "InstanceShape" {
     default = "VM.Standard1.2"
 }


### PR DESCRIPTION
Add a `timeout_minutes` parameter to the provider that provides a minimum timeout for each resource operation. E.g. setting `60` will make all resources timeout after 60 minutes.