### PR TITLE
subnet: fix security_list_ids ordering

### DIFF
--- a/core/subnet_resource.go
+++ b/core/subnet_resource.go
@@ -3,9 +3,9 @@
 package core
 
 import (
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/oracle/terraform-provider-baremetal/client"
 	"github.com/oracle/terraform-provider-baremetal/crud"
-	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func SubnetResource() *schema.Resource {
@@ -41,9 +41,10 @@ func SubnetResource() *schema.Resource {
 				ForceNew: true,
 			},
 			"security_list_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
 				ForceNew: true,
+				Set:      schema.HashString,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -54,11 +55,11 @@ func SubnetResource() *schema.Resource {
 				Computed: true,
 			},
 			"dhcp_options_id": {
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 			"dns_label": {
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 			"id": {

--- a/core/subnet_resource_crud.go
+++ b/core/subnet_resource_crud.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/MustWin/baremetal-sdk-go"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/oracle/terraform-provider-baremetal/crud"
 )
 
@@ -57,7 +58,7 @@ func (s *SubnetResourceCrud) Create() (e error) {
 
 	if rawSecurityListIDs, ok := s.D.GetOk("security_list_ids"); ok {
 		securityListIDs := []string{}
-		for _, val := range rawSecurityListIDs.([]interface{}) {
+		for _, val := range rawSecurityListIDs.(*schema.Set).List() {
 			securityListIDs = append(securityListIDs, val.(string))
 		}
 		opts.SecurityListIDs = securityListIDs
@@ -104,7 +105,7 @@ func (s *SubnetResourceCrud) SetData() {
 	s.D.Set("dns_label", s.Resource.DNSLabel)
 	s.D.Set("route_table_id", s.Resource.RouteTableID)
 	s.D.Set("vcn_id", s.Resource.VcnID)
-	s.D.Set("security_list_ids", s.Resource.SecurityListIDs)
+	s.D.Set("security_list_ids", makeSetFromStrings(s.Resource.SecurityListIDs))
 	s.D.Set("state", s.Resource.State)
 	s.D.Set("time_created", s.Resource.TimeCreated.String())
 	s.D.Set("virtual_router_ip", s.Resource.VirtualRouterIP)
@@ -113,4 +114,14 @@ func (s *SubnetResourceCrud) SetData() {
 
 func (s *SubnetResourceCrud) Delete() (e error) {
 	return s.Client.DeleteSubnet(s.D.Id(), nil)
+}
+
+// makeSetFromStrings encodes an []string into a
+// *schema.Set in the appropriate structure for the schema
+func makeSetFromStrings(ss []string) *schema.Set {
+	st := &schema.Set{F: schema.HashString}
+	for _, s := range ss {
+		st.Add(s)
+	}
+	return st
 }

--- a/core_subnet_test.go
+++ b/core_subnet_test.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/MustWin/baremetal-sdk-go"
-	"github.com/oracle/terraform-provider-baremetal/client/mocks"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/oracle/terraform-provider-baremetal/client/mocks"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -43,15 +43,15 @@ func (s *ResourceCoreSubnetTestSuite) SetupTest() {
 	s.TimeCreated = baremetal.Time{Time: time.Now()}
 
 	s.Config = `
-		resource "baremetal_core_subnet" "t" {
-			availability_domain = "availabilitydomainid"
-			compartment_id = "compartmentid"
-			display_name = "display_name"
-      cidr_block = "10.10.10.0/24"
-      route_table_id = "routetableid"
-      vcn_id = "vcnid"
-      security_list_ids = ["slid1", "slid2"]
-		}
+resource "baremetal_core_subnet" "t" {
+  availability_domain = "availabilitydomainid"
+  compartment_id      = "compartmentid"
+  display_name        = "display_name"
+  cidr_block          = "10.10.10.0/24"
+  route_table_id      = "routetableid"
+  vcn_id              = "vcnid"
+  security_list_ids   = ["slid1", "slid2"]
+}
 	`
 
 	s.Config += testProviderConfig
@@ -65,8 +65,9 @@ func (s *ResourceCoreSubnetTestSuite) SetupTest() {
 		ID:                 "id",
 		RouteTableID:       "routetableid",
 		SecurityListIDs: []string{
-			"slid1",
+			// Note: sorted by schema.HashString
 			"slid2",
+			"slid1",
 		},
 		State: baremetal.ResourceAvailable,
 		TimeCreated: baremetal.Time{
@@ -122,14 +123,14 @@ func (s *ResourceCoreSubnetTestSuite) TestCreateResourceCoreSubnetWithoutDisplay
 	s.Client.On("GetSubnet", "id").Return(s.DeletedRes, nil).Times(2)
 
 	s.Config = `
-		resource "baremetal_core_subnet" "t" {
-			availability_domain = "availabilitydomainid"
-			compartment_id = "compartmentid"
-      cidr_block = "10.10.10.0/24"
-      route_table_id = "routetableid"
-      vcn_id = "vcnid"
-      security_list_ids = ["slid1", "slid2"]
-		}
+resource "baremetal_core_subnet" "t" {
+  availability_domain = "availabilitydomainid"
+  compartment_id      = "compartmentid"
+  cidr_block          = "10.10.10.0/24"
+  route_table_id      = "routetableid"
+  vcn_id              = "vcnid"
+  security_list_ids   = ["slid1", "slid2"]
+}
 	`
 
 	s.Config += testProviderConfig
@@ -162,15 +163,15 @@ func (s *ResourceCoreSubnetTestSuite) TestCreateResourceCoreSubnetWithoutDisplay
 
 func (s ResourceCoreSubnetTestSuite) TestUpdateCompartmentIDForcesNewSubnet() {
 	config := `
-		resource "baremetal_core_subnet" "t" {
-			availability_domain = "availabilitydomainid"
-			compartment_id = "new_compartmentid"
-			display_name = "display_name"
-	    cidr_block = "10.10.10.0/24"
-	    route_table_id = "routetableid"
-	    vcn_id = "vcnid"
-	    security_list_ids = ["slid1", "slid2"]
-		}
+resource "baremetal_core_subnet" "t" {
+  availability_domain = "availabilitydomainid"
+  compartment_id      = "new_compartmentid"
+  display_name        = "display_name"
+  cidr_block          = "10.10.10.0/24"
+  route_table_id      = "routetableid"
+  vcn_id              = "vcnid"
+  security_list_ids   = ["slid1", "slid2"]
+}
 	`
 
 	config += testProviderConfig
@@ -183,8 +184,9 @@ func (s ResourceCoreSubnetTestSuite) TestUpdateCompartmentIDForcesNewSubnet() {
 		ID:                 "new_id",
 		RouteTableID:       "routetableid",
 		SecurityListIDs: []string{
-			"slid1",
+			// Note: sorted by schema.HashString
 			"slid2",
+			"slid1",
 		},
 		State: baremetal.ResourceAvailable,
 		TimeCreated: baremetal.Time{


### PR DESCRIPTION
`baremetal_core_subnet.security_list_ids` with multiple items causes
destroy/add on every `terraform apply`, even with no changes. API state
does not respect item ordering, so config and API state do not match
(except when items happen to have exactly the same sorting as used by
API state). Because local and remote state do not match, terraform will
attempt to change remote state to match on every `apply`.

Change `security_list_ids` from `TypeList` to `TypeSet`, so terraform
only considers membership, not ordering.

Fixes https://github.com/oracle/terraform-provider-baremetal/issues/44